### PR TITLE
trousers: enable tcs service explicitly

### DIFF
--- a/recipes-tpm/trousers/trousers_0.3.13.bb
+++ b/recipes-tpm/trousers/trousers_0.3.13.bb
@@ -86,7 +86,7 @@ USERADD_PARAM_${PN} = "-M -d /var/lib/tpm -s /bin/false -g tss tss"
 
 SYSTEMD_PACKAGES = "${PN}"
 SYSTEMD_SERVICE_${PN} = "tcsd.service"
-SYSTEMD_AUTO_ENABLE = "disable"
+SYSTEMD_AUTO_ENABLE = "enable"
 
 do_install_append() {
         install -d ${D}${sysconfdir}/init.d


### PR DESCRIPTION
trousers is the core service providing TSS for tpm 1.2 device.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>