### PR TITLE
linux-yocto: tpm: sync kernel configs from meta-security layer

### DIFF
--- a/recipes-kernel/linux/linux-yocto/tpm.cfg
+++ b/recipes-kernel/linux/linux-yocto/tpm.cfg
@@ -11,8 +11,11 @@
 .
 ..........................................................................
 
+CONFIG_HW_RANDOM_TPM=y
 CONFIG_TCG_TPM=y
+CONFIG_TCG_TIS_CORE=y
 CONFIG_TCG_TIS=y
+CONFIG_SECURITYFS=y
 CONFIG_TCG_NSC=m
 CONFIG_TCG_ATMEL=m
 CONFIG_TCG_INFINEON=m


### PR DESCRIPTION
This fixes some runtime issues like:
| systemd-remount-fs[25]: mount: /sys/kernel/security: mount point not mounted or bad option.
systemd-remount-fs[25]: /bin/mount for /sys/kernel/security exited with exit status 32.

Signed-off-by: Ming Liu <liu.ming50@gmail.com>